### PR TITLE
add #useAfter|Before() methods, docs, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,34 @@ along with a callback that is used to determine when the next middleware should 
 
 For more info checkout the tests and examples.
 
+
+### API
+
+
+#### Middleware()
+
+- @constructor
+
+Exported by "generic-middleware" module
+
+
+#### Middleware#use(fn)
+
+- @param {`Function`} fn - function to inject into the stack
+
+
+#### Middleware#useAfter(after, fn)
+
+- @param {`Function`?} [after] - function in the stack to follow (if null, add to the tail)
+- @param {`Function`} fn - function to inject into the stack
+
+
+#### Middleware#useBefore(before, fn)
+
+- @param {`Function`?} [before] - function in the stack to precede (if null, add to the head)
+- @param {`Function`} fn - function to inject into the stack
+
+
 ### License
 
 [MIT](http://alessioalex.mit-license.org/)

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,6 +3,9 @@
 var getParams = require('get-parameter-names');
 var noop = function emptyFn() {};
 
+/**
+@constructor
+*/
 function Middleware() {
   if (!(this instanceof Middleware)) {
     return new Middleware();
@@ -14,6 +17,9 @@ function Middleware() {
   this.init = this.init.bind(this);
 }
 
+/**
+@param {Function} fn - function to inject into the stack
+*/
 Middleware.prototype.use = function use(fn) {
   var params = getParams(fn);
   var firstParam = (params && params[0]) ? params[0].toLowerCase() : '';
@@ -23,6 +29,32 @@ Middleware.prototype.use = function use(fn) {
   } else {
     this._stack.push(fn);
   }
+};
+
+/**
+@param {Function?} [after] - function in the stack to follow (if null, add to the tail)
+@param {Function} fn - function to inject into the stack
+*/
+Middleware.prototype.useAfter = function useAfter(after, fn) {
+  var index = this._stack.indexOf(after);
+  if (!after || index < 0) {
+    this._stack.push(fn);
+    return;
+  }
+  this._stack.splice(index + 1, 0, fn);
+};
+
+/**
+@param {Function?} [before] - function in the stack to precede (if null, add to the head)
+@param {Function} fn - function to inject into the stack
+*/
+Middleware.prototype.useBefore = function useBefore(before, fn) {
+  var index = this._stack.indexOf(before);
+  if (!before || index < 0) {
+    this._stack.unshift(fn);
+    return;
+  }
+  this._stack.splice(index, 0, fn);
 };
 
 Middleware.prototype.addErrorHandler = function addErrorHandler(fn) {

--- a/test/unit/middleware.js
+++ b/test/unit/middleware.js
@@ -50,6 +50,54 @@ test('middleware', function(q) {
     t.end();
   });
 
+  q.test('#useAfter(null, fn) should add fn to tail', function(t) {
+    var md = new Middleware();
+    var first = function(foo, bar) {};
+    var last = function(foo, bar) {};
+    md.use(first);
+    md.useAfter(null, last);
+
+    t.deepEqual(md._stack, [first, last]);
+    t.end();
+  });
+
+  q.test('#useAfter(afterFn, fn) should add fn ahead of beforeFn', function(t) {
+    var md = new Middleware();
+    var first = function(foo, bar) {};
+    var last = function(foo, bar) {};
+    var middle = function(foo, bar) {};
+    md.use(first);
+    md.use(last);
+    md.useAfter(first, middle);
+
+    t.deepEqual(md._stack, [first, middle, last]);
+    t.end();
+  });
+
+  q.test('#useBefore(null, fn) should add fn to head', function(t) {
+    var md = new Middleware();
+    var fn = function(foo, bar) {};
+    var first = function(foo, bar) {};
+    md.use(fn);
+    md.useBefore(null, first);
+
+    t.deepEqual(md._stack, [first, fn]);
+    t.end();
+  });
+
+  q.test('#useBefore(beforeFn, fn) should add fn ahead of beforeFn', function(t) {
+    var md = new Middleware();
+    var first = function(foo, bar) {};
+    var last = function(foo, bar) {};
+    var middle = function(foo, bar) {};
+    md.use(first);
+    md.use(last);
+    md.useBefore(last, middle);
+
+    t.deepEqual(md._stack, [first, middle, last]);
+    t.end();
+  });
+
   q.test('it should add the error handler', function(t) {
     var md = new Middleware();
     md.addErrorHandler(noop);


### PR DESCRIPTION
These methods allow a particular middleware stack instance to be modified under controlled circumstances (discouraging users from modifying the "private" array directly).

If you build a library that uses this project, and make your own built-in handlers accessible, your users will be able to tailor your particular stack instance in ways that are specific to their needs.
