### PR TITLE
(chore) bump devDeps, fix up ESLint errors/conf

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "extends": ["eslint:recommended"],
   "env": {
     "browser": true,
     "node": true
@@ -35,13 +36,13 @@
     "no-empty": 2,                   // http://eslint.org/docs/rules/no-empty
     "no-ex-assign": 2,               // http://eslint.org/docs/rules/no-ex-assign
     "no-extra-boolean-cast": 0,      // http://eslint.org/docs/rules/no-extra-boolean-cast
+    "no-extra-parens": [2, "functions"],               // http://eslint.org/docs/rules/no-extra-parens
     "no-extra-semi": 2,              // http://eslint.org/docs/rules/no-extra-semi
     "no-func-assign": 2,             // http://eslint.org/docs/rules/no-func-assign
     "no-inner-declarations": 2,      // http://eslint.org/docs/rules/no-inner-declarations
     "no-invalid-regexp": 2,          // http://eslint.org/docs/rules/no-invalid-regexp
     "no-irregular-whitespace": 2,    // http://eslint.org/docs/rules/no-irregular-whitespace
     "no-obj-calls": 2,               // http://eslint.org/docs/rules/no-obj-calls
-    "no-reserved-keys": 2,           // http://eslint.org/docs/rules/no-reserved-keys
     "no-sparse-arrays": 2,           // http://eslint.org/docs/rules/no-sparse-arrays
     "no-unreachable": 2,             // http://eslint.org/docs/rules/no-unreachable
     "use-isnan": 2,                  // http://eslint.org/docs/rules/use-isnan
@@ -122,10 +123,10 @@
     "no-new-object": 2,              // http://eslint.org/docs/rules/no-new-object
     "no-spaced-func": 2,             // http://eslint.org/docs/rules/no-spaced-func
     "no-trailing-spaces": 2,         // http://eslint.org/docs/rules/no-trailing-spaces
-    "no-wrap-func": 2,               // http://eslint.org/docs/rules/no-wrap-func
     "no-underscore-dangle": 0,       // http://eslint.org/docs/rules/no-underscore-dangle
     "one-var": [2, "never"],         // http://eslint.org/docs/rules/one-var
     "padded-blocks": [2, "never"],   // http://eslint.org/docs/rules/padded-blocks
+    "quote-props": [2, "as-needed", { "keywords": true }],           // http://eslint.org/docs/rules/quote-props
     "semi": [2, "always"],           // http://eslint.org/docs/rules/semi
     "semi-spacing": [2, {            // http://eslint.org/docs/rules/semi-spacing
       "before": false,
@@ -136,7 +137,7 @@
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
     "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
-    "spaced-line-comment": 2,        // http://eslint.org/docs/rules/spaced-line-comment
+    "spaced-comment": 2,        // http://eslint.org/docs/rules/spaced-line-comment
 
 /**
  * Other

--- a/examples/markdowner.js
+++ b/examples/markdowner.js
@@ -18,7 +18,7 @@ app.use(function readFile(opts, data, next) {
 });
 
 app.use(function lintMarkdown(opts, data, next) {
-  var lintOpts = { 'strings': {} };
+  var lintOpts = { strings: {} };
   lintOpts.strings[path.basename(opts.path)] = data.content;
 
   lint(lintOpts, function(err, result) {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "get-parameter-names": "^0.2.0"
   },
   "devDependencies": {
-    "eslint": "^0.24.0",
-    "husky": "^0.8.1",
+    "eslint": "^1.5.1",
+    "husky": "^0.10.1",
     "proxyquire": "^1.6.0",
     "sinon": "^1.15.4",
     "tape": "^4.0.0"

--- a/test/unit/middleware.js
+++ b/test/unit/middleware.js
@@ -111,9 +111,9 @@ test('middleware', function(q) {
 
     // mocking an array object with a bad length, for testing purposes
     md._stack = {
-      '0': noop,
-      '1': fn1,
-      '2': fn2,
+      0: noop,
+      1: fn1,
+      2: fn2,
       length: 2
     };
 


### PR DESCRIPTION
I updated the versions of ESLint and husky. As some of the ESLint rules have been removed, I had to replace some of your rules with references to the new rules that are equivalent.

As a side note, your .eslintrc could probably be much smaller / simpler if you used a shared config with most of the same settings, e.g. https://github.com/Flet/eslint-config-semistandard
