### PR TITLE
allow for multiple error handlers

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var getParams = require('get-parameter-names');
-var noop = function emptyFn() {};
 
 function Middleware() {
   if (!(this instanceof Middleware)) {
@@ -9,7 +8,7 @@ function Middleware() {
   }
 
   this._stack = [];
-  this._errorHandler = noop;
+  this._errorHandlers = [];
 
   this.init = this.init.bind(this);
 }
@@ -26,7 +25,7 @@ Middleware.prototype.use = function use(fn) {
 };
 
 Middleware.prototype.addErrorHandler = function addErrorHandler(fn) {
-  this._errorHandler = fn;
+  this._errorHandlers.push(fn);
 };
 
 Middleware.prototype.init = function init() {
@@ -50,7 +49,15 @@ Middleware.prototype._handle = function _handle(err, index, arg) {
     this._callStackFn(index, args);
   } else {
     args.unshift(err);
-    this._errorHandler.apply(null, args);
+    this._handleError(args);
+  }
+};
+
+Middleware.prototype._handleError = function _handleError(args) {
+  var ehLength = this._errorHandlers.length;
+  var eh;
+  for (eh = 0; eh < ehLength; eh += 1) {
+    this._errorHandlers[eh].apply(null, args);
   }
 };
 

--- a/test/unit/middleware.js
+++ b/test/unit/middleware.js
@@ -18,7 +18,7 @@ test('middleware', function(q) {
     var md = Middleware();
 
     t.deepEqual(md._stack, []);
-    t.ok(typeof md._errorHandler === 'function');
+    t.deepEqual(md._errorHandlers, []);
     t.end();
   });
 
@@ -54,7 +54,7 @@ test('middleware', function(q) {
     var md = new Middleware();
     md.addErrorHandler(noop);
 
-    t.equal(md._errorHandler, noop);
+    t.deepEqual(md._errorHandlers, [noop]);
     t.end();
   });
 
@@ -69,16 +69,19 @@ test('middleware', function(q) {
     t.end();
   });
 
-  q.test('it should call the error handler', function(t) {
+  q.test('it should call the error handlers', function(t) {
     var md = new Middleware();
     var err = new Error('oh noes');
-    var handleErrors = sinon.spy();
+    var firstHandler = sinon.spy();
+    var lastHandler = sinon.spy();
     var args = ['foo', 'bar'];
 
-    md._errorHandler = handleErrors;
+    md.addErrorHandler(firstHandler);
+    md.addErrorHandler(lastHandler);
 
     md._handle(err, 0, args);
-    t.ok(handleErrors.calledWith(err, args[0], args[1]));
+    t.ok(firstHandler.calledWith(err, args[0], args[1]));
+    t.ok(lastHandler.calledWith(err, args[0], args[1]));
 
     t.end();
   });


### PR DESCRIPTION
Without affecting the external interface (with the exception of the "private" `_errorHandler` property), I've made it so that multiple error handlers can be registered.

For each error, all registered error handlers are synchronously called.

If you are building a library using this project, then this provides your users the same powers you yourself have to react to errors. This is very useful for debugging and for extensibility.
